### PR TITLE
Shift form to right on parents selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,14 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1 id="titulo">Cuestionario de Conducta de CONNERS para PROFESORES</h1>
-    <div class="tabs">
-        <button id="tab-profesores" class="tab active" data-tipo="profesores">Profesores</button>
-        <button id="tab-padres" class="tab" data-tipo="padres">Padres</button>
-    </div>
-    <p id="instrucciones"></p>
-    <form id="conners-form" class="card">
+    <div id="content">
+        <h1 id="titulo">Cuestionario de Conducta de CONNERS para PROFESORES</h1>
+        <div class="tabs">
+            <button id="tab-profesores" class="tab active" data-tipo="profesores">Profesores</button>
+            <button id="tab-padres" class="tab" data-tipo="padres">Padres</button>
+        </div>
+        <p id="instrucciones"></p>
+        <form id="conners-form" class="card">
         <div class="form-group">
             <label for="nombre-nino">Nombre completo del ni&ntilde;o:</label>
             <input type="text" id="nombre-nino" name="nombreNino" required>
@@ -65,7 +66,8 @@
         <button type="button" id="calcular">Calcular</button>
     </form>
 
-    <p id="resultado"></p>
+        <p id="resultado"></p>
+    </div>
     <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -71,6 +71,7 @@ function calcularResultado() {
 function seleccionarTipo(tipo) {
     const tabProfesores = document.getElementById('tab-profesores');
     const tabPadres = document.getElementById('tab-padres');
+    const content = document.getElementById('content');
 
     if (tipo === 'padres') {
         preguntas = preguntasPadres;
@@ -78,12 +79,14 @@ function seleccionarTipo(tipo) {
         tabPadres.classList.add('active');
         document.getElementById('titulo').textContent = 'Cuestionario de Conducta de CONNERS para PADRES';
         document.getElementById('instrucciones').textContent = '';
+        content.classList.add('right-block');
     } else {
         preguntas = preguntasProfesores;
         tabPadres.classList.remove('active');
         tabProfesores.classList.add('active');
         document.getElementById('titulo').textContent = 'Cuestionario de Conducta de CONNERS para PROFESORES';
         document.getElementById('instrucciones').textContent = '';
+        content.classList.remove('right-block');
     }
 
     crearCuestionario();

--- a/style.css
+++ b/style.css
@@ -4,6 +4,15 @@ body {
     background-color: #f4f4f4;
 }
 
+/* Contenedor principal para poder mover el formulario */
+#content {
+    max-width: 600px;
+}
+
+#content.right-block {
+    margin-left: auto;
+}
+
 form.card {
     max-width: 600px;
     background: #fff;


### PR DESCRIPTION
## Summary
- wrap the page content in a `#content` container
- add styles so the container shifts right when `right-block` class is present
- toggle that class from JavaScript when selecting the "Padres" tab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68439d7129ec8328bc08991804250117