### PR TITLE
Fix error display in Conners form

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ function calcularResultado() {
     let completo = true;
     for (let i = 1; i <= preguntas.length; i++) {
         const seleccionado = document.querySelector('input[name="p' + i + '"]:checked');
-        const mensaje = document.querySelector('#cuestionario tr:nth-child(' + i + ') .mensaje-error');
+        const mensaje = document.querySelector('#cuestionario tbody tr:nth-child(' + i + ') .mensaje-error');
         if (!seleccionado) {
             completo = false;
             if (mensaje) mensaje.style.display = 'inline';


### PR DESCRIPTION
## Summary
- correct CSS selector for question error messages so they display properly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843ccda87448328b027c099c898757e